### PR TITLE
modes/rpc: simplify append and remove redundant nil check

### DIFF
--- a/packages/modes/rpc.go
+++ b/packages/modes/rpc.go
@@ -88,24 +88,16 @@ func (r *rpcServer) getApis(namespace string) []any {
 	switch namespace {
 	case jsonrpc.GetNamespace(jsonrpc.NamespaceAdmin):
 		adminApi := newAdminApi(r)
-		for _, v := range adminApi.GetApis() {
-			apis = append(apis, v)
-		}
+		apis = append(apis, adminApi.GetApis()...)
 	case jsonrpc.GetNamespace(jsonrpc.NamespaceIBAX):
 		ibaxApi := jsonrpc.NewIbaxApi(r.mode)
-		for _, v := range ibaxApi.GetApis() {
-			apis = append(apis, v)
-		}
+		apis = append(apis, ibaxApi.GetApis()...)
 	case jsonrpc.GetNamespace(jsonrpc.NamespaceNet):
 		netApi := jsonrpc.NewNetApi()
-		for _, v := range netApi.GetApis() {
-			apis = append(apis, v)
-		}
+		apis = append(apis, netApi.GetApis()...)
 	case jsonrpc.GetNamespace(jsonrpc.NamespaceDebug):
 		debugApi := jsonrpc.NewDebugApi()
-		for _, v := range debugApi.GetApis() {
-			apis = append(apis, v)
-		}
+		apis = append(apis, debugApi.GetApis()...)
 	}
 	return apis
 }
@@ -119,12 +111,10 @@ func (r *rpcServer) enableRpc(namespaces string) error {
 	for _, m := range strings.Split(namespaces, ",") {
 		name := strings.TrimSpace(m)
 		funcs := r.getApis(name)
-		if funcs != nil {
-			for _, f := range funcs {
-				err := srv.RegisterName(name, f)
-				if err != nil {
-					return err
-				}
+		for _, f := range funcs {
+			err := srv.RegisterName(name, f)
+			if err != nil {
+				return err
 			}
 		}
 	}


### PR DESCRIPTION
We can append to the `apis` slice by unpacking so we don't need to use a for loop.

> slice = append(slice, anotherSlice...) https://pkg.go.dev/builtin#append


From the Go specification:

> "1. For a nil slice, the number of iterations is 0." https://go.dev/ref/spec#For_range

Therefore, an additional nil check for before the loop is unnecessary.